### PR TITLE
Update HiperGator Environment for A100 GPUs

### DIFF
--- a/Zooniverse/hipergator_enviroment.yml
+++ b/Zooniverse/hipergator_enviroment.yml
@@ -2,14 +2,17 @@ name: Zooniverse
 channels: 
   - defaults
 dependencies:
-  - python==3.7
-  - geopandas
-  - shapely
-  - pandas
-  - pytest
-  - rasterio
+  - pytorch::pytorch
+  - pytorch::torchvision
+  - nvidia::cudatoolkit=11.1
+  - dask
+  - distributed
   - pip
   - pip:
+    - deepforest
+    - pandas
+    - geopandas
+    - dask_jobqueue
     - panoptescli
     - comet_ml
     - paramiko
@@ -20,6 +23,6 @@ dependencies:
     - xmltodict
     - Panoptes
     - PyYAML
-
-
-
+    - shapely
+    - pytest
+    - rasterio


### PR DESCRIPTION
The existing environment doesn't work on the new A100 GPUs.
This change forces pytorch to install from the correct channels and moves dependencies to pip that prevent this.