### PR TITLE
User new branch naming for r-lib/actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         with:
             fetch-depth: 3
             
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
         
       - name: Cache R packages
         uses: actions/cache@v2


### PR DESCRIPTION
The r-lib/actions repo has made a breaking change to it's branching naming. This updates to the current recommendation.